### PR TITLE
Modify API definition to improve library and code sample generation

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -3399,7 +3399,7 @@ components:
         example: 026e7634-24d7-486c-a0bb-4a17fd0eebc5
     idem-query:
       in: query
-      name: idempotency_key
+      name: idempotency_key2
       required: false
       description: >
         A string of no longer than 256 characters that uniquely identifies this
@@ -3409,7 +3409,6 @@ components:
       schema:
         type: string
         maxLength: 256
-        example: 026e7634-24d7-486c-a0bb-4a17fd0eebc5
   schemas:
     date_filter:
       type: object
@@ -17647,7 +17646,6 @@ paths:
               metadata:
                 memo: rafting trip
               attachment: ./cool.pdf
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: operational
               mail_type: usps_first_class
               check_number: 10001
@@ -17686,7 +17684,6 @@ paths:
               metadata:
                 memo: rafting trip
               attachment: ./cool.pdf
-              send_date: '2017-11-01T00:00:00.000Z'
               mail_type: usps_first_class
               check_number: 10001
             encoding:
@@ -17737,7 +17734,6 @@ paths:
               metadata:
                 memo: rafting trip
               attachment: ./cool.pdf
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: operational
               mail_type: usps_first_class
               check_number: 10001
@@ -19711,18 +19707,9 @@ paths:
                 name: Harry
               metadata:
                 spiffy: 'true'
-              send_date: '2017-11-01T00:00:00.000Z'
               extra_service: registered
               custom_envelope: null
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2'
-                top: '2'
-                right: '2'
-                pages: 1-2,4-5
-              fsc: true
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/letter_editable'
@@ -19762,18 +19749,9 @@ paths:
                 name: Harry
               metadata:
                 spiffy: 'true'
-              send_date: '2017-11-01T00:00:00.000Z'
               extra_service: registered
               custom_envelope: null
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2'
-                bottom: '2'
-                right: '2'
-                pages: 1,4
-              fsc: true
             encoding:
               to:
                 style: deepObject
@@ -19826,18 +19804,9 @@ paths:
                 name: Harry
               metadata:
                 spiffy: 'true'
-              send_date: '2017-11-01T00:00:00.000Z'
               extra_service: registered
               custom_envelope: null
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2'
-                bottom: '2'
-                left: '2'
-                pages: 1,3-5
-              fsc: true
       responses:
         '200':
           $ref: '#/components/responses/post_letter'
@@ -20828,24 +20797,15 @@ paths:
                 address_state: CA
                 address_zip: '94107'
                 address_country: US
-              front: tmpl_a1234dddg
-              back: tmpl_a1234dddg
+              front: <html><body>Hello</body></html>
+              back: <html><body>Goodbye</body></html>
               size: 6x9
               mail_type: usps_first_class
               merge_variables:
                 name: Harry
               metadata:
                 spiffy: 'true'
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2.5'
-                top: '2.5'
-                right: '2.5'
-                pages: front,back
-              fsc: true
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/postcard_editable'
@@ -20875,24 +20835,15 @@ paths:
                 address_state: CA
                 address_zip: '94107'
                 address_country: US
-              front: tmpl_c94e83ca2cd5121
-              back: tmpl_c94e83ca2cd5121
+              front: <html><body>Hello</body></html>
+              back: <html><body>Goodbye</body></html>
               size: 6x9
               mail_type: usps_first_class
               merge_variables:
                 name: Harry
               metadata:
                 spiffy: 'true'
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2.5'
-                bottom: '2.5'
-                right: '2.5'
-                pages: back
-              fsc: true
             encoding:
               to:
                 style: deepObject
@@ -20935,24 +20886,15 @@ paths:
                 address_state: CA
                 address_zip: '94107'
                 address_country: US
-              front: tmpl_a1234dddg
-              back: tmpl_a1234dddg
+              front: <html><body>Hello</body></html>
+              back: <html><body>Goodbye</body></html>
               size: 6x9
               mail_type: usps_first_class
               merge_variables:
                 name: Harry
               metadata:
                 spiffy: 'true'
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2.5'
-                bottom: '2.5'
-                left: '2.5'
-                pages: front
-              fsc: true
       responses:
         '200':
           $ref: '#/components/responses/post_postcard'
@@ -22820,16 +22762,7 @@ paths:
               mail_type: usps_standard
               merge_variables:
                 name: Harry
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2.5'
-                top: '2.5'
-                right: '2.5'
-                pages: inside,outside
-              fsc: true
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/self_mailer_editable'
@@ -22845,16 +22778,7 @@ paths:
               mail_type: usps_standard
               merge_variables:
                 name: Harry
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2.5'
-                top: '2.5'
-                right: '2.5'
-                pages: inside,outside
-              fsc: true
             encoding:
               merge_variables:
                 style: deepObject
@@ -22877,16 +22801,7 @@ paths:
               mail_type: usps_standard
               merge_variables:
                 name: Harry
-              send_date: '2017-11-01T00:00:00.000Z'
               use_type: marketing
-              qr_code:
-                position: relative
-                redirect_url: https://www.lob.com
-                width: '2.5'
-                top: '2.5'
-                right: '2.5'
-                pages: inside,outside
-              fsc: true
       responses:
         '200':
           $ref: '#/components/responses/post_self_mailer'

--- a/resources/checks/checks.yml
+++ b/resources/checks/checks.yml
@@ -200,7 +200,6 @@ post:
           metadata:
             memo: rafting trip
           attachment: "./cool.pdf"
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: operational
           mail_type: usps_first_class
           check_number: 10001
@@ -239,7 +238,6 @@ post:
           metadata:
             memo: rafting trip
           attachment: "./cool.pdf"
-          send_date: "2017-11-01T00:00:00.000Z"
           mail_type: usps_first_class
           check_number: 10001
         encoding:
@@ -290,7 +288,6 @@ post:
           metadata:
             memo: rafting trip
           attachment: "./cool.pdf"
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: operational
           mail_type: usps_first_class
           check_number: 10001

--- a/resources/letters/letters.yml
+++ b/resources/letters/letters.yml
@@ -211,18 +211,9 @@ post:
             name: Harry
           metadata:
             spiffy: "true"
-          send_date: "2017-11-01T00:00:00.000Z"
           extra_service: registered
           custom_envelope: null
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2"
-            top: "2"
-            right: "2"
-            pages: "1-2,4-5"
-          fsc: true
 
       application/x-www-form-urlencoded:
         schema:
@@ -261,18 +252,10 @@ post:
             name: Harry
           metadata:
             spiffy: "true"
-          send_date: "2017-11-01T00:00:00.000Z"
           extra_service: registered
           custom_envelope:
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2"
-            bottom: "2"
-            right: "2"
-            pages: "1,4"
-          fsc: true
+
         encoding:
           to:
             style: deepObject
@@ -324,18 +307,9 @@ post:
             name: Harry
           metadata:
             spiffy: "true"
-          send_date: "2017-11-01T00:00:00.000Z"
           extra_service: registered
           custom_envelope:
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2"
-            bottom: "2"
-            left: "2"
-            pages: "1,3-5"
-          fsc: true
 
   responses:
     "200":

--- a/resources/postcards/postcards.yml
+++ b/resources/postcards/postcards.yml
@@ -207,24 +207,15 @@ post:
             address_state: "CA"
             address_zip: "94107"
             address_country: "US"
-          front: tmpl_a1234dddg
-          back: tmpl_a1234dddg
+          front: "<html><body>Hello</body></html>"
+          back: "<html><body>Goodbye</body></html>"
           size: "6x9"
           mail_type: usps_first_class
           merge_variables:
             name: Harry
           metadata:
             spiffy: "true"
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2.5"
-            top: "2.5"
-            right: "2.5"
-            pages: "front,back"
-          fsc: true
 
       application/x-www-form-urlencoded:
         schema:
@@ -255,24 +246,16 @@ post:
             address_state: "CA"
             address_zip: "94107"
             address_country: "US"
-          front: tmpl_c94e83ca2cd5121
-          back: tmpl_c94e83ca2cd5121
+          front: "<html><body>Hello</body></html>"
+          back: "<html><body>Goodbye</body></html>"
           size: "6x9"
           mail_type: usps_first_class
           merge_variables:
             name: Harry
           metadata:
             spiffy: "true"
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2.5"
-            bottom: "2.5"
-            right: "2.5"
-            pages: "back"
-          fsc: true
+
         encoding:
           to:
             style: deepObject
@@ -316,24 +299,15 @@ post:
             address_state: "CA"
             address_zip: "94107"
             address_country: "US"
-          front: tmpl_a1234dddg
-          back: tmpl_a1234dddg
+          front: "<html><body>Hello</body></html>"
+          back: "<html><body>Goodbye</body></html>"
           size: "6x9"
           mail_type: usps_first_class
           merge_variables:
             name: Harry
           metadata:
             spiffy: "true"
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2.5"
-            bottom: "2.5"
-            left: "2.5"
-            pages: "front"
-          fsc: true
 
   responses:
     "200":

--- a/resources/self_mailers/self_mailers.yml
+++ b/resources/self_mailers/self_mailers.yml
@@ -191,16 +191,7 @@ post:
           mail_type: usps_standard
           merge_variables:
             name: Harry
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2.5"
-            top: "2.5"
-            right: "2.5"
-            pages: "inside,outside"
-          fsc: true
 
       application/x-www-form-urlencoded:
         schema:
@@ -217,16 +208,8 @@ post:
           mail_type: usps_standard
           merge_variables:
             name: Harry
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2.5"
-            top: "2.5"
-            right: "2.5"
-            pages: "inside,outside"
-          fsc: true
+
         encoding:
           merge_variables:
             style: deepObject
@@ -250,16 +233,7 @@ post:
           mail_type: usps_standard
           merge_variables:
             name: Harry
-          send_date: "2017-11-01T00:00:00.000Z"
           use_type: marketing
-          qr_code:
-            position: "relative"
-            redirect_url: "https://www.lob.com"
-            width: "2.5"
-            top: "2.5"
-            right: "2.5"
-            pages: "inside,outside"
-          fsc: true
 
   responses:
     "200":

--- a/shared/parameters/idempotency.yml
+++ b/shared/parameters/idempotency.yml
@@ -18,7 +18,7 @@ idem-header:
 idem-query:
   in: query
 
-  name: idempotency_key
+  name: idempotency_key2
 
   required: false
 
@@ -30,4 +30,3 @@ idem-query:
   schema:
     type: string
     maxLength: 256
-    example: 026e7634-24d7-486c-a0bb-4a17fd0eebc5


### PR DESCRIPTION
There are two idempotency keys. 
Idempotency-Key which is a header value
idempotency_key which is a param value

This is allows a developer to pass the key via either method (but not both). Code generators are going to remove any dashes or underscores and end up with two identical variable idempotencyKey.

The rest of the changes are to remove properties from examples in the API definition. 

fsc is a beta feature, so won't work with API without permission
qr_codes is a premium feature and wont' work without permission
send_date is a premium feature and wont' work without permission
template_id that is passed doesn't exist, because it hasn't been created in my account, I replaced with raw html.