### PR TITLE
remove idempotency key from query param

### DIFF
--- a/dist/lob-api-bundled.yml
+++ b/dist/lob-api-bundled.yml
@@ -3397,18 +3397,6 @@ components:
         type: string
         maxLength: 256
         example: 026e7634-24d7-486c-a0bb-4a17fd0eebc5
-    idem-query:
-      in: query
-      name: idempotency_key2
-      required: false
-      description: >
-        A string of no longer than 256 characters that uniquely identifies this
-        resource. For more help integrating idempotency keys, refer to our <a
-        href="https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#idempotent-requests-12"
-        target="_blank">implementation guide</a>.
-      schema:
-        type: string
-        maxLength: 256
   schemas:
     date_filter:
       type: object
@@ -17607,7 +17595,6 @@ paths:
         - Checks
       parameters:
         - $ref: '#/components/parameters/idem-header'
-        - $ref: '#/components/parameters/idem-query'
       requestBody:
         required: true
         content:
@@ -19664,7 +19651,6 @@ paths:
         - Letters
       parameters:
         - $ref: '#/components/parameters/idem-header'
-        - $ref: '#/components/parameters/idem-query'
       requestBody:
         required: true
         content:
@@ -20764,7 +20750,6 @@ paths:
         - Postcards
       parameters:
         - $ref: '#/components/parameters/idem-header'
-        - $ref: '#/components/parameters/idem-query'
       requestBody:
         required: true
         content:
@@ -22743,7 +22728,6 @@ paths:
         - Self Mailers
       parameters:
         - $ref: '#/components/parameters/idem-header'
-        - $ref: '#/components/parameters/idem-query'
       requestBody:
         required: true
         content:

--- a/resources/checks/checks.yml
+++ b/resources/checks/checks.yml
@@ -161,8 +161,7 @@ post:
 
   parameters:
     - $ref: "../../shared/parameters/idempotency.yml#/idem-header"
-    - $ref: "../../shared/parameters/idempotency.yml#/idem-query"
-
+   
   requestBody:
     required: true
     content:

--- a/resources/letters/letters.yml
+++ b/resources/letters/letters.yml
@@ -169,8 +169,7 @@ post:
 
   parameters:
     - $ref: "../../shared/parameters/idempotency.yml#/idem-header"
-    - $ref: "../../shared/parameters/idempotency.yml#/idem-query"
-
+  
   requestBody:
     required: true
     content:

--- a/resources/postcards/postcards.yml
+++ b/resources/postcards/postcards.yml
@@ -173,8 +173,7 @@ post:
 
   parameters:
     - $ref: "../../shared/parameters/idempotency.yml#/idem-header"
-    - $ref: "../../shared/parameters/idempotency.yml#/idem-query"
-
+  
   requestBody:
     required: true
     content:

--- a/resources/self_mailers/self_mailers.yml
+++ b/resources/self_mailers/self_mailers.yml
@@ -171,8 +171,7 @@ post:
 
   parameters:
     - $ref: "../../shared/parameters/idempotency.yml#/idem-header"
-    - $ref: "../../shared/parameters/idempotency.yml#/idem-query"
-
+  
   requestBody:
     required: true
     content:

--- a/shared/parameters/idempotency.yml
+++ b/shared/parameters/idempotency.yml
@@ -14,19 +14,3 @@ idem-header:
     type: string
     maxLength: 256
     example: 026e7634-24d7-486c-a0bb-4a17fd0eebc5
-
-idem-query:
-  in: query
-
-  name: idempotency_key2
-
-  required: false
-
-  description: >
-    A string of no longer than 256 characters that uniquely identifies
-    this resource. For more help integrating idempotency keys, refer to
-    our <a href="https://help.lob.com/print-and-mail/building-a-mail-strategy/managing-mail-settings#idempotent-requests-12" target="_blank">implementation guide</a>.
-
-  schema:
-    type: string
-    maxLength: 256


### PR DESCRIPTION
Removed from checks, letters, postcards and self-mailers.

This functionality of this key is duplicated by the idempotency key passed via the header.

This change is for demonstration purposes. The renaming of the query param variable would be a customization needed with code generation.